### PR TITLE
fix: round coordinates to even numbers

### DIFF
--- a/helper_funcs.py
+++ b/helper_funcs.py
@@ -41,3 +41,7 @@ def quad_min_max(quad_obj):
     max_xy = max(all_vert, key=lambda x: (x[0], x[1]))
 
     return (min_xy, max_xy)
+
+
+def round_to_even(value):
+    return round(value / 2) * 2

--- a/operators.py
+++ b/operators.py
@@ -7,7 +7,7 @@ from .element import (
     ListProperty,
     ValueProperty,
 )
-from .helper_funcs import create_quad, create_materials, quad_min_max
+from .helper_funcs import create_quad, create_materials, quad_min_max, round_to_even
 
 
 class OT_Import_WaterXML(bpy.types.Operator, ImportHelper):
@@ -263,10 +263,10 @@ def create_waterQuad_xml(object) -> WaterQuads:
     obj_min_xy = obj_minmax[0]
     obj_max_xy = obj_minmax[1]
     quad_object_xml = WaterQuads()
-    quad_object_xml.minX = round(obj_min_xy[0])
-    quad_object_xml.maxX = round(obj_max_xy[0])
-    quad_object_xml.minY = round(obj_min_xy[1])
-    quad_object_xml.maxY = round(obj_max_xy[1])
+    quad_object_xml.minX = round_to_even(obj_min_xy[0])
+    quad_object_xml.maxX = round_to_even(obj_max_xy[0])
+    quad_object_xml.minY = round_to_even(obj_min_xy[1])
+    quad_object_xml.maxY = round_to_even(obj_max_xy[1])
     quad_object_xml.type = object.waterProperties.water_type
 
     is_inv_str = str(object.waterProperties.water_is_invisible)
@@ -297,10 +297,10 @@ def create_calmingQuad_xml(object) -> CalmingQuads:
     obj_min_xy = obj_minmax[0]
     obj_max_xy = obj_minmax[1]
     quad_object_xml = CalmingQuads()
-    quad_object_xml.minX = round(obj_min_xy[0])
-    quad_object_xml.maxX = round(obj_max_xy[0])
-    quad_object_xml.minY = round(obj_min_xy[1])
-    quad_object_xml.maxY = round(obj_max_xy[1])
+    quad_object_xml.minX = round_to_even(obj_min_xy[0])
+    quad_object_xml.maxX = round_to_even(obj_max_xy[0])
+    quad_object_xml.minY = round_to_even(obj_min_xy[1])
+    quad_object_xml.maxY = round_to_even(obj_max_xy[1])
     quad_object_xml.fDampening = object.waterProperties.water_fDampening
     return quad_object_xml
 
@@ -310,10 +310,10 @@ def create_waveQuad_xml(object) -> WaveQuads:
     obj_min_xy = obj_minmax[0]
     obj_max_xy = obj_minmax[1]
     quad_object_xml = WaveQuads()
-    quad_object_xml.minX = round(obj_min_xy[0])
-    quad_object_xml.maxX = round(obj_max_xy[0])
-    quad_object_xml.minY = round(obj_min_xy[1])
-    quad_object_xml.maxY = round(obj_max_xy[1])
+    quad_object_xml.minX = round_to_even(obj_min_xy[0])
+    quad_object_xml.maxX = round_to_even(obj_max_xy[0])
+    quad_object_xml.minY = round_to_even(obj_min_xy[1])
+    quad_object_xml.maxY = round_to_even(obj_max_xy[1])
     quad_object_xml.amplitude = object.waterProperties.water_amplitude
     quad_object_xml.x_direction = object.waterProperties.water_xDirection
     quad_object_xml.y_direction = object.waterProperties.water_yDirection


### PR DESCRIPTION
This is how R* handles it.
Could also notify the user that we had to round his values but I'm lazy
